### PR TITLE
Stop main box from overlapping title

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -73,9 +73,15 @@ html {
     overflow: hidden;
 }
 
+.centered-container {
+    height: 95%;
+    overflow: auto; /* This will allow scrolling */
+    vertical-align: middle;
+}
+
 #title {
     position: relative;
-    top: 10%;
+    top: 30px;
     left: 0;
     right: 0;
     color: #FFF;
@@ -84,8 +90,8 @@ html {
     font-weight: 300;
     font-size: 40px;
     letter-spacing: 10px;
-    /* margin-top: -60px; */
     padding-left: 10px;
+    margin-bottom: 60px;
 }
 #title span {
     background: -webkit-linear-gradient(white, gray);
@@ -102,15 +108,6 @@ body {
     overflow: hidden; /* This will prevent scrolling */
 }
 
-.centered-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between; /* Align children at the start of the container */
-    align-items: center;
-    height: 95%;
-    overflow: auto; /* This will allow scrolling */
-}
-
 main {
     max-width: 800px;
     margin: auto;
@@ -118,9 +115,7 @@ main {
     background-color: rgba(255, 255, 255, 0.7);
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.01);
     border-radius: 8px;
-    position: relative;
     transition: all 0.5s ease;
-    /* flex-grow: 1; */
 }
 
 input {


### PR DESCRIPTION
Fixes this annoying bug in the CSS where the main box would expand both up and down, eventually blocking the title. Now, the main box only expands downwards. 

AI-generated code isn't the best _yet_ :)